### PR TITLE
Fix bug in set.coeffs() to load both C and S coefficients from lists

### DIFF
--- a/wrap/pyharm/shc.py
+++ b/wrap/pyharm/shc.py
@@ -746,7 +746,7 @@ class Shc:
                                  f'do not match ({len(n)} vs. {len(m)}).')
 
             def set_cs(x, cs_str):
-                _check_flt_ndarray(c, 1, 'The \'{cs_str}\' variable')
+                _check_flt_ndarray(x, 1, 'The \'{cs_str}\' variable')
 
                 if len(x) != len(n):
                     msg  = f'The length of \'{cs_str}\' is {len(x)}, but must '

--- a/wrap/pyharm/shc.py
+++ b/wrap/pyharm/shc.py
@@ -746,7 +746,7 @@ class Shc:
                                  f'do not match ({len(n)} vs. {len(m)}).')
 
             def set_cs(x, cs_str):
-                _check_flt_ndarray(x, 1, 'The \'{cs_str}\' variable')
+                _check_flt_ndarray(x, 1, f'The \'{cs_str}\' variable')
 
                 if len(x) != len(n):
                     msg  = f'The length of \'{cs_str}\' is {len(x)}, but must '


### PR DESCRIPTION
Previously, the `set.coeffs()` function supported setting only the C coefficients *when using a list* to define spherical harmonic coefficients, leaving the S coefficients unsupported. This update ensures that both C and S coefficients are now properly handled. 